### PR TITLE
Update storyListView.js & fixed keyExtractor issue

### DIFF
--- a/src/components/storyList/view/storyListView.js
+++ b/src/components/storyList/view/storyListView.js
@@ -25,6 +25,7 @@ class StoryListView extends Component {
     return (
       <View style={styles.container}>
         <FlatList
+          keyExtractor={(item,index)=>index.toString()}
           data={stories}
           horizontal
           renderItem={({ item, index }) => (


### PR DESCRIPTION
keyExtractor is added into FlatList.
keyExtractor must be define into FlatList for solving "Failed child context type: Invalid child context 'virtualizedCell.cellKey' of type 'number' supplied to 'CellRenderer', expected 'string'.